### PR TITLE
Take svlint configuration file from environment variable.

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -152,7 +152,7 @@ impl LanguageServer for Backend {
         };
 
         if config.option.linter {
-            let config_svlint = search_config(&PathBuf::from(".svlint.toml"));
+            let config_svlint = search_config_svlint(&PathBuf::from(".svlint.toml"));
             debug!("config_svlint: {:?}", config_svlint);
 
             let linter = match generate_linter(config_svlint) {
@@ -241,6 +241,19 @@ fn search_config(config: &Path) -> Option<PathBuf> {
     } else {
         None
     }
+}
+
+fn search_config_svlint(config: &Path) -> Option<PathBuf> {
+    if let Ok(c) = env::var("SVLINT_CONFIG") {
+        let candidate = Path::new(&c);
+        if candidate.exists() {
+            return Some(candidate.to_path_buf());
+        } else {
+            debug!("SVLINT_CONFIG=\"{}\" does not exist. Searching hierarchically.", c);
+        }
+    }
+
+    search_config(config)
 }
 
 fn generate_config(config: Option<PathBuf>) -> std::result::Result<Config, String> {


### PR DESCRIPTION
This PR is the partner of https://github.com/dalance/svlint/pull/137

Explanation repeated here:

Look for special envvar SVLINT_CONFIG.
If SVLINT_CONFIG is not set (as currently), then hierarchical search (no change).
If SVLINT_CONFIG is set but is invalid, then hierarchical search (no change).
If SVLINT_CONFIG is set AND --config is given, then use SVLINT_CONFIG.

Enables use with standardised environments like GNU Modulefiles.
E.g. $ module load svlint would append to PATH and set SVLINT_CONFIG.
Or, more realistically, $ module load projectFoo would set environment
variables for all the project's tools (where svlint is one of many).
Different projects can then have different rule-sets, and everybody working
on the same project uses the same rule-set.