### PR TITLE
Refactor: various code readability improvements and dependency upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cbf586c80ada5e5ccdecae80d3ef0854f224e2dd74435f8d87e6831b8d0a38"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -59,21 +59,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
 dependencies = [
  "funty",
  "radium",
@@ -95,9 +95,9 @@ checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfg-if"
@@ -107,9 +107,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.15"
+version = "3.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
 dependencies = [
  "atty",
  "bitflags",
@@ -128,7 +128,7 @@ version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -157,12 +157,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
+version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
 dependencies = [
  "cfg-if",
- "num_cpus",
+ "hashbrown 0.12.1",
+ "lock_api",
 ]
 
 [[package]]
@@ -219,7 +220,6 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -241,17 +241,6 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -302,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -318,13 +307,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -342,6 +328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httparse"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,19 +346,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "itoa"
@@ -395,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libloading"
@@ -407,6 +393,16 @@ checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -420,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.89.2"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e0dedfd52cc32325598b2631e0eba31b7b708959676a9f837042f276b09a2"
+checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
 dependencies = [
  "bitflags",
  "serde",
@@ -433,15 +429,15 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "nom"
@@ -477,7 +473,7 @@ dependencies = [
  "nom 6.1.2",
  "nom_locate 1.0.0",
  "nom_locate 2.1.0",
- "nom_locate 3.0.1",
+ "nom_locate 3.0.2",
 ]
 
 [[package]]
@@ -488,7 +484,7 @@ checksum = "c5c5a5a7eae83c3c9d53bdfd94e8bb1d700c6bb78f00d25af71263fc07cf477b"
 dependencies = [
  "nom-packrat-macros",
  "nom_locate 1.0.0",
- "nom_locate 3.0.1",
+ "nom_locate 3.0.2",
 ]
 
 [[package]]
@@ -509,7 +505,7 @@ checksum = "e0de2967d4f9065b08596dcfa9be631abc4997951b9e0a93e2279b052370bacc"
 dependencies = [
  "nom-recursive-macros",
  "nom_locate 1.0.0",
- "nom_locate 3.0.1",
+ "nom_locate 3.0.2",
 ]
 
 [[package]]
@@ -531,7 +527,7 @@ dependencies = [
  "nom 6.1.2",
  "nom-tracable-macros",
  "nom_locate 1.0.0",
- "nom_locate 3.0.1",
+ "nom_locate 3.0.2",
 ]
 
 [[package]]
@@ -568,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "nom_locate"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302954611858a07e00f85110b4ea61859dea77d63f109bd60ab7b8eb533bbacb"
+checksum = "4689294073dda8a54e484212171efdcb6b12b1908fd70c3dc3eec15b8833b06d"
 dependencies = [
  "bytecount 0.6.2",
  "memchr",
@@ -578,23 +574,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
+name = "num_threads"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.5"
+name = "once_cell"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
-dependencies = [
- "libc",
-]
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "os_str_bytes"
@@ -609,10 +601,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.7"
+name = "pin-project"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -646,18 +658,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -670,28 +682,29 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -706,15 +719,15 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -724,6 +737,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -747,11 +766,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 0.4.7",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -768,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -790,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "static_assertions"
@@ -856,7 +875,7 @@ dependencies = [
  "nom-packrat",
  "nom-recursive",
  "nom-tracable",
- "nom_locate 3.0.1",
+ "nom_locate 3.0.2",
  "str-concat",
  "sv-parser-macros",
  "sv-parser-syntaxtree",
@@ -915,10 +934,8 @@ dependencies = [
  "anyhow",
  "clap",
  "enquote",
- "futures",
  "log",
  "serde",
- "serde_derive",
  "serde_json",
  "simplelog",
  "sv-parser",
@@ -958,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -973,18 +990,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -997,7 +1014,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "libc",
  "num_threads",
  "time-macros",
@@ -1011,9 +1028,9 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1026,20 +1043,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
 dependencies = [
- "autocfg",
+ "once_cell",
  "pin-project-lite",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1048,16 +1065,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1070,34 +1087,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-lsp"
-version = "0.14.1"
+name = "tower"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701465c44f9e5655785b1420f3dea1d33d15f2fea2e0a65d25c4fd91ec0e6238"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-lsp"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
 dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
  "dashmap",
  "futures",
+ "httparse",
  "log",
  "lsp-types",
- "nom 6.1.2",
+ "memchr",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-lsp-macros",
- "tower-service",
 ]
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb72acc00b574cffa151d0725b3b26404554b371b4c6e059c58eb23f9f097140"
+checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
 dependencies = [
- "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1110,13 +1147,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.5"
+name = "tracing"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
- "matches",
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
 ]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"
@@ -1128,16 +1194,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"
@@ -1163,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.16"
+version = "3.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
+checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
 dependencies = [
  "atty",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ clap         = {version = "3.1.15", features = ["derive"]}
 enquote      = "1"
 futures      = "0.3"
 log          = "0.4"
-serde        = "1"
-serde_derive = "1"
+serde        = {version = "1", features = ["derive"]}
 serde_json   = "1"
 simplelog    = "0.12"
 svlint       = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ pre-release-replacements    = [
 anyhow       = "1"
 clap         = {version = "3.1.15", features = ["derive"]}
 enquote      = "1"
-futures      = "0.3"
 log          = "0.4"
 serde        = {version = "1", features = ["derive"]}
 serde_json   = "1"
@@ -36,7 +35,7 @@ svlint       = "0.5.2"
 sv-parser    = "0.11.1"
 tokio        = {version = "1.6", features = ["io-std", "macros", "rt", "test-util"]}
 toml         = "0.5"
-tower-lsp    = "0.14"
+tower-lsp    = "0.17"
 
 #[patch.crates-io]
 #sv-parser = {path = "../sv-parser/sv-parser"}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -232,17 +232,15 @@ impl LanguageServer for Backend {
 }
 
 fn search_config(config: &Path) -> Option<PathBuf> {
-    if let Ok(current) = env::current_dir() {
-        for dir in current.ancestors() {
-            let candidate = dir.join(config);
-            if candidate.exists() {
-                return Some(candidate);
-            }
+    let curr = env::current_dir().ok()?;
+    curr.ancestors().find_map(|dir| {
+        let candidate = dir.join(config);
+        if candidate.exists() {
+            Some(candidate)
+        } else {
+            None
         }
-        None
-    } else {
-        None
-    }
+    })
 }
 
 fn search_config_svlint(config: &Path) -> Option<PathBuf> {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -95,7 +95,7 @@ impl Backend {
                                     Position::new(line, col),
                                     Position::new(line, col + failed.len as u32),
                                 ),
-                                Some(DiagnosticSeverity::Warning),
+                                Some(DiagnosticSeverity::WARNING),
                                 Some(NumberOrString::String(String::from(failed.name))),
                                 Some(String::from("svls")),
                                 String::from(failed.hint),
@@ -119,7 +119,7 @@ impl Backend {
                                     Position::new(line, col),
                                     Position::new(line, col + len),
                                 ),
-                                Some(DiagnosticSeverity::Error),
+                                Some(DiagnosticSeverity::ERROR),
                                 None,
                                 Some(String::from("svls")),
                                 String::from("parse error"),
@@ -146,7 +146,7 @@ impl LanguageServer for Backend {
         let config = match generate_config(config_svls) {
             Ok(x) => x,
             Err(x) => {
-                self.client.show_message(MessageType::Warning, &x).await;
+                self.client.show_message(MessageType::WARNING, &x).await;
                 Config::default()
             }
         };
@@ -158,7 +158,7 @@ impl LanguageServer for Backend {
             let linter = match generate_linter(config_svlint) {
                 Ok(x) => x,
                 Err(x) => {
-                    self.client.show_message(MessageType::Warning, &x).await;
+                    self.client.show_message(MessageType::WARNING, &x).await;
                     Linter::new(LintConfig::new().enable_all())
                 }
             };
@@ -176,7 +176,7 @@ impl LanguageServer for Backend {
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::Full,
+                    TextDocumentSyncKind::FULL,
                 )),
                 workspace: Some(WorkspaceServerCapabilities {
                     workspace_folders: Some(WorkspaceFoldersServerCapabilities {
@@ -198,7 +198,7 @@ impl LanguageServer for Backend {
 
     async fn initialized(&self, _: InitializedParams) {
         self.client
-            .log_message(MessageType::Info, &format!("server initialized"))
+            .log_message(MessageType::INFO, &format!("server initialized"))
             .await;
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -262,25 +262,22 @@ fn search_config_svlint(config: &Path) -> Option<PathBuf> {
 }
 
 fn generate_config(config: Option<PathBuf>) -> std::result::Result<Config, String> {
-    if let Some(config) = config {
-        if let Ok(s) = std::fs::read_to_string(&config) {
-            if let Ok(config) = toml::from_str(&s) {
-                Ok(config)
-            } else {
-                Err(format!(
-                    "Failed to parse {}. Enable all lint rules.",
-                    config.to_string_lossy()
-                ))
-            }
-        } else {
-            Err(format!(
-                "Failed to read {}. Enable all lint rules.",
-                config.to_string_lossy()
-            ))
-        }
-    } else {
-        Ok(Config::default())
-    }
+    let path = match config {
+        Some(c) => c,
+        _ => return Ok(Default::default()),
+    };
+    let text = std::fs::read_to_string(&path).map_err(|_| {
+        format!(
+            "Failed to read {}. Enable all lint rules.",
+            path.to_string_lossy()
+        )
+    })?;
+    toml::from_str(&text).map_err(|_| {
+        format!(
+            "Failed to parse {}. Enable all lint rules.",
+            path.to_string_lossy()
+        )
+    })
 }
 
 fn generate_linter(config: Option<PathBuf>) -> std::result::Result<Linter, String> {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -55,15 +55,10 @@ impl Backend {
             for define in &config.verilog.defines {
                 let mut define = define.splitn(2, '=');
                 let ident = String::from(define.next().unwrap());
-                let text = if let Some(x) = define.next() {
-                    if let Ok(x) = enquote::unescape(x, None) {
-                        Some(DefineText::new(x, None))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+                let text = define
+                    .next()
+                    .and_then(|x| enquote::unescape(x, None).ok())
+                    .map(|x| DefineText::new(x, None));
                 let define = Define::new(ident.clone(), vec![], text);
                 defines.insert(ident, Some(define));
             }
@@ -114,10 +109,7 @@ impl Backend {
                         let line_end = get_line_end(s, pos);
                         let len = line_end - pos as u32;
                         ret.push(Diagnostic::new(
-                            Range::new(
-                                Position::new(line, col),
-                                Position::new(line, col + len),
-                            ),
+                            Range::new(Position::new(line, col), Position::new(line, col + len)),
                             Some(DiagnosticSeverity::ERROR),
                             None,
                             Some(String::from("svls")),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -96,9 +96,9 @@ impl Backend {
                                     Position::new(line, col + failed.len as u32),
                                 ),
                                 Some(DiagnosticSeverity::WARNING),
-                                Some(NumberOrString::String(String::from(failed.name))),
+                                Some(NumberOrString::String(failed.name)),
                                 Some(String::from("svls")),
-                                String::from(failed.hint),
+                                failed.hint,
                                 None,
                                 None,
                             ));
@@ -198,7 +198,7 @@ impl LanguageServer for Backend {
 
     async fn initialized(&self, _: InitializedParams) {
         self.client
-            .log_message(MessageType::INFO, &format!("server initialized"))
+            .log_message(MessageType::INFO, "server initialized")
             .await;
     }
 
@@ -296,7 +296,7 @@ fn generate_linter(config: Option<PathBuf>) -> std::result::Result<Linter, Strin
             ))
         }
     } else {
-        Err(format!(".svlint.toml is not found. Enable all lint rules."))
+        Err(String::from(".svlint.toml is not found. Enable all lint rules."))
     }
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -108,27 +108,24 @@ impl Backend {
             }
             Err(x) => {
                 debug!("parse_error: {:?}", x);
-                match x {
-                    sv_parser::Error::Parse(Some((path, pos))) => {
-                        if path == PathBuf::from("") {
-                            let (line, col) = get_position(s, pos);
-                            let line_end = get_line_end(s, pos);
-                            let len = line_end - pos as u32;
-                            ret.push(Diagnostic::new(
-                                Range::new(
-                                    Position::new(line, col),
-                                    Position::new(line, col + len),
-                                ),
-                                Some(DiagnosticSeverity::ERROR),
-                                None,
-                                Some(String::from("svls")),
-                                String::from("parse error"),
-                                None,
-                                None,
-                            ));
-                        }
+                if let sv_parser::Error::Parse(Some((path, pos))) = x {
+                    if path.as_path() == Path::new("") {
+                        let (line, col) = get_position(s, pos);
+                        let line_end = get_line_end(s, pos);
+                        let len = line_end - pos as u32;
+                        ret.push(Diagnostic::new(
+                            Range::new(
+                                Position::new(line, col),
+                                Position::new(line, col + len),
+                            ),
+                            Some(DiagnosticSeverity::ERROR),
+                            None,
+                            Some(String::from("svls")),
+                            String::from("parse error"),
+                            None,
+                            None,
+                        ));
                     }
-                    _ => (),
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,8 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, messages) = LspService::new(|client| Backend::new(client));
-    Server::new(stdin, stdout)
-        .interleave(messages)
+    let (service, messages) = LspService::new(Backend::new);
+    Server::new(stdin, stdout, messages)
         .serve(service)
         .await;
 }


### PR DESCRIPTION
Hello there! I noticed that the project could use a little refactoring in the `backend.rs`. Moreover, I realized that many of the dependencies are far outdated. In fact, #135 fails due to breaking changes from `tower-lsp@0.14` to `0.17`. This PR resolves this by adjusting to the breaking changes upstream while cleaning up some code in the process.

# Dependency Upgrades/Changes
* `serde_derive` has been removed. The `serde` crate recommends using the `derive` feature instead.
* Remove `futures` crate, which is apparently unused. This actually shortens the compilation times a bit since we no longer have to compile `futures-executor`.
* Bump `tower-lsp` to `0.17`. This, of course, brings breaking changes in the code, which I fixed in this PR.
* Bump `tokio` to `1.18`. Although `Cargo.toml` shows `1.6`, the `Cargo.lock` has been updated to use `1.18` thanks to the `cargo update` utility.

# Refactoring
* Many explicit `match` statements have been converted to short-circuiting functions so that they are significantly less nested.
* Many nested `match` statements have been converted to using the monadic methods provided by `Result` and `Option`.
* Redundant `String::from(string)` wrappings have been removed.
* Some unnecessary usage of `format` have been removed. This should avoid some allocations.

And that should be all the changes I've made. I don't expect any of the original behavior to change—unless (of course) upstream dependencies introduce unexpected behavior. Thanks! 🎉