### PR TITLE
Update link to svlint configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ linter = true
 
 Linter uses `.svlint.toml` at the root of repository.
 If `.svlint.toml` can't be used, all lint rules are enabled.
-Please see [svlint#configuration](https://github.com/dalance/svlint#configuration) for the detailed information.
+Please see [svlint#configuration](https://github.com/dalance/svlint/blob/master/MANUAL.md#configuration) for the detailed information.
 
 ## Usage
 


### PR DESCRIPTION
Updates the link to the svlint configuration docs to point to the new location in MANUAL.md.