### PR TITLE
Update Emacs config section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,13 @@ In configuration file
       (flycheck-mode t)
       (add-to-list 'lsp-language-id-configuration '(verilog-mode . "verilog")))))
 ```
+
+### Emacs with [verilog-ext](https://github.com/gmlarumbe/verilog-ext)
+
+```elisp
+(require 'verilog-ext)
+(verilog-ext-mode-setup)
+(verilog-ext-eglot-set-server 've-svls) ;`eglot' config
+(verilog-ext-lsp-set-server 've-svls)   ; `lsp' config
+```
+


### PR DESCRIPTION
This language server can be easily configured for Emacs also through the [`verilog-ext`](https://github.com/gmlarumbe/verilog-ext/) extension package.

It supports Emacs builtin `eglot` client as well as `lsp-mode`.