### PR TITLE
Add configuration for Helix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,15 @@ In configuration file
 (verilog-ext-lsp-set-server 've-svls)   ; `lsp' config
 ```
 
+### Helix
+
+In `languages.toml`:
+
+```toml
+[language-server.svls]
+command = "svls"
+
+[[language]]
+name = "verilog"
+language-servers = ["svls"]
+```


### PR DESCRIPTION
Since the README already lists some example configurations for various editors, I thought maybe we could add one for [Helix](https://helix-editor.com/) as well. I quickly tested it and it works for me.